### PR TITLE
詳細画面への画面遷移とデータの表示を可能とする

### DIFF
--- a/app/controllers/api/pokemons_controller.rb
+++ b/app/controllers/api/pokemons_controller.rb
@@ -30,14 +30,11 @@ class Api::PokemonsController < ApplicationController
         response = Net::HTTP.get(url)
         pokemon_data = JSON.parse(response)
         
-        # 名前を日本語に変換。pokemon_data["results"]でAPIから返されたデータを取得。
-        pokemon_data["results"].each do |pokemon|
-            # 英語で取得したデータを日本語へ変換する
-            pokemon_data["name"] = translate_pokemon_name(pokemon_data["name"])
-        end
+        # 英語で取得したデータを日本語へ変換する
+        pokemon_data["name"] = translate_pokemon_name(pokemon_data["name"])
 
         # 変換後のデータをJSON形式で返す。
-        render json: { results: pokemon_data["results"] }
+        render json: pokemon_data
     end
   
     private

--- a/pokemon_zukan_react/package-lock.json
+++ b/pokemon_zukan_react/package-lock.json
@@ -12,6 +12,7 @@
         "cra-template": "1.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-router-dom": "^7.1.5",
         "react-scripts": "5.0.1"
       }
     },
@@ -3525,6 +3526,11 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
     },
     "node_modules/@types/eslint": {
       "version": "8.56.12",
@@ -13763,6 +13769,52 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.1.5.tgz",
+      "integrity": "sha512-8BUF+hZEU4/z/JD201yK6S+UYhsf58bzYIDq2NS1iGpwxSXDu7F+DeGSkIXMFBuHZB21FSiCzEcUb18cQNdRkA==",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.1.5.tgz",
+      "integrity": "sha512-/4f9+up0Qv92D3bB8iN5P1s3oHAepSGa9h5k6tpTFlixTTskJZwKGhJ6vRJ277tLD1zuaZTt95hyGWV1Z37csQ==",
+      "dependencies": {
+        "react-router": "7.1.5"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -14664,6 +14716,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -16030,6 +16087,11 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/pokemon_zukan_react/package.json
+++ b/pokemon_zukan_react/package.json
@@ -7,6 +7,7 @@
     "cra-template": "1.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-router-dom": "^7.1.5",
     "react-scripts": "5.0.1"
   },
   "scripts": {

--- a/pokemon_zukan_react/src/App.js
+++ b/pokemon_zukan_react/src/App.js
@@ -1,40 +1,20 @@
-import React, { useEffect, useState } from 'react';
-import './App.css';
+import React from "react";
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom"; //react-router-domを使って、ページを切り替えられるようにする
+import PokemonList from "./components/PokemonList"; // PokemonListという画面を使うために読み込む
+import PokemonDetail from "./components/PokemonDetail"; //PokemonDetailという画面を使うために読み込む
 
-// Appという関数コンポーネント(画面の部品)を定義しています。
 function App() {
-  // データの一覧を管理するpokemonという変数と、その状態を更新するためのsetpokemonを定義しています。
-  // []はpokemonの初期値を空の配列(データがない状態)に設定しています。
-  const [pokemon, setPokemon] = useState([]);
-
-  // useEffect は、ページが読み込まれたときに1回だけ実行される。
-  useEffect(() => {
-    // fetch関数で指定したURLへアクセスし、データを取得する
-    fetch('http://localhost:3000/api/pokemons')
-      // APIから返されたデータをJSON形式に変換
-      .then(pokemon_data => pokemon_data.json())
-      // APIのレスポンスの内容(data.results)を変数pokemonにセット、データが存在しない場合はから配列にする
-      .then(data => {
-        setPokemon(data.results || []);
-      })
-      // エラーが出た際にはコンソール上に出力する
-      .catch(error => console.error(error));
-  }, []);
-  
   return (
-    <div className="App">
-      <div>
-        <h1>ポケモン図鑑 データリスト</h1>
-        <ul>
-          {pokemon.map((pokemonItem) => {
-            // URLをsplit("/")で"/"で区切り、slice(-2, -1)でidを取得。配列でデータが取得されるので、[0]で最初の要素を取得するß
-            const id = pokemonItem.url.split("/").slice(-2, -1)[0];
-            
-            return<li key={id}>{pokemonItem.name}</li>})}
-        </ul>
-      </div>
-    </div>
+    <Router>
+      <Routes>
+        {/* path="/"にきたら、PokemonListコンポーネントを表示する(一覧画面を表示する) */}
+        <Route path="/" element={<PokemonList />} />
+        {/* path="/pokemon/:id"にきたら、PokemonDetailコンポーネントを表示する(詳細画面を表示する) */}
+        <Route path="/pokemon/:id" element={<PokemonDetail />} />
+      </Routes>
+    </Router>
   );
 }
 
 export default App;
+// 他の場所でも使えるようにする

--- a/pokemon_zukan_react/src/components/PokemonDetail.js
+++ b/pokemon_zukan_react/src/components/PokemonDetail.js
@@ -1,0 +1,117 @@
+import React, { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+
+function PokemonDetail() {
+    const { id } = useParams();
+    const [pokemon, setPokemon] = useState(null);
+    const [japaneseName, setJapaneseName] = useState(""); // 日本語名を保存するステート
+    const [typesInJapanese, setTypesInJapanese] = useState([]); // 日本語のタイプ名を保存するステート
+    const [abilitiesInJapanese, setAbilitiesInJapanese] = useState([]); // 日本語の特性名を保存するステート
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        // ポケモンの基本データを取得
+        fetch(`https://pokeapi.co/api/v2/pokemon/${id}`)
+            .then((response) => response.json())
+            .then((data) => {
+                setPokemon(data); // 取得した基本データ（ポケモンの詳細情報）をステートに保存
+            })
+            .catch((error) => console.error(error));
+
+    }, [id]);
+
+    useEffect(() => {
+        if (!pokemon) return; // pokemon がまだ取得されていない場合は処理しない
+
+        // 日本語の名前、タイプ、特性を取得
+        // fetchでAPIからデータを取得する
+        fetch(`https://pokeapi.co/api/v2/pokemon-species/${id}`)
+            // JSON形式でデータを取得する
+            .then((response) => response.json())
+            .then((data) => {
+                // データの中から日本語のデータを受け取る。
+                const jpName = data.names.find((name) => name.language.name === "ja");
+                // 日本語名のデータがあればデータをセットし、なければ「不明」にする
+                setJapaneseName(jpName ? jpName.name : "不明");
+            })
+            .catch((error) => console.error(error));
+
+        // ポケモンのタイプを日本語で取得
+        // fetchTypeNamesという関数を作っている。asyncは非同期処理
+        const fetchTypeNames = async () => {
+            // pokemon?.typesは変数内にデータが含まれているか確認をしている。ない場合はエラーにならないように[](空のリスト)を入れている
+            const types = pokemon?.types || [];
+            // Promise.allを使い、すべてのタイプを日本語へ変換する
+            const translatedTypes = await Promise.all(
+                // mapを使って、タイプごとに「英語 → 日本語」の変換をする
+                types.map(async (type) => {
+                    // fetchを使い、データを取得する。type.type.urlで「タイプ」の詳細情報を取得する
+                    const typeData = await fetch(type.type.url)
+                        // fetchで取得したデータをJSON形式へ変換する
+                        .then((response) => response.json())
+                        .then((data) => {
+                            // データの中からnames(名前のリスト)を探し、日本語("ja")を見つける
+                            const jpType = data.names.find((name) => name.language.name === "ja");
+                            // 日本語が見つかればjpType.nameを返す。そうでなければ英語の名前を使う
+                            return jpType ? jpType.name : type.type.name;
+                        })
+                        .catch((error) => console.error(error));
+                    // 変換したタイプの名前を返す。
+                    return typeData;
+                })
+            );
+            // タイプをすべて変換し、setTypesInJapaneseへセットする。
+            setTypesInJapanese(translatedTypes);
+        };
+
+        // ポケモンの特性を日本語で取得
+        // fetchAbilitiesNamesという関数を作っている。asyncは非同期処理
+        const fetchAbilitiesNames = async () => {
+            // pokemon?.abilitiesは変数内にデータが含まれているか確認をしている。ない場合はエラーにならないように[](空のリスト)を入れている
+            const abilities = pokemon?.abilities || [];
+            // Promise.allを使い、すべてのタイプを日本語へ変換する
+            const translatedAbilities = await Promise.all(
+                // mapを使って、特性ごとに「英語 → 日本語」の変換をする 
+                abilities.map(async (ability) => {
+                    // fetchを使い、データを取得する。ability.ability.urlで「特性」の詳細情報を取得す
+                    const abilityData = await fetch(ability.ability.url)
+                        // fetchで取得したデータをJSON形式へ変換する
+                        .then((response) => response.json())
+                        .then((data) => {
+                            // データの中からnames(名前のリスト)を探し、日本語("ja")を見つける
+                            const jpAbility = data.names.find((name) => name.language.name === "ja");
+                            // 日本語が見つかればjpAbility.nameを返す。そうでなければ英語の名前を使う
+                            return jpAbility ? jpAbility.name : ability.ability.name;
+                        })
+                        .catch((error) => console.error(error));
+                    // 変換した特性の名前を返す。
+                    return abilityData;
+                })
+            );
+            // 特性をすべて変換し、setAbilitiesInJapaneseへセットする。
+            setAbilitiesInJapanese(translatedAbilities);
+        };
+
+        fetchTypeNames(); // タイプ名の日本語変換
+        fetchAbilitiesNames(); // 特性名の日本語変換
+
+    }, [pokemon, id]);
+
+    if (!pokemon) return <p>Loading...</p>;
+
+    return (
+        <div>
+            <h1>{japaneseName}</h1>
+            <img src={pokemon.sprites.front_default} alt={pokemon.name} />
+            <p>高さ: {pokemon.height}m</p>
+            <p>重さ: {pokemon.weight}kg</p>
+            <p>タイプ: {typesInJapanese.join(", ")}</p> {/* 日本語のタイプ名を表示 */}
+            <p>特性: {abilitiesInJapanese.join(", ")}</p> {/* 日本語の特性名を表示 */}
+
+            <button onClick={() => navigate("/")}>戻る</button>
+        </div>
+    );
+}
+
+export default PokemonDetail;
+// 他の場所でも使えるようにする

--- a/pokemon_zukan_react/src/components/PokemonList.js
+++ b/pokemon_zukan_react/src/components/PokemonList.js
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+// PokemonListという関数コンポーネント(画面の部品)を定義しています。
+function PokemonList() {
+  // データの一覧を管理するpokemonという変数と、その状態を更新するためのsetpokemonを定義しています。
+  // []はpokemonの初期値を空の配列(データがない状態)に設定しています。
+  const [pokemon, setPokemon] = useState([]);
+
+  // useEffect は、ページが読み込まれたときに1回だけ実行される。
+  useEffect(() => {
+    // fetch関数で指定したURLへアクセスし、データを取得する
+    fetch('http://localhost:3000/api/pokemons')
+      // APIから返されたデータをJSON形式に変換
+      .then(pokemon_data => pokemon_data.json())
+      // APIのレスポンスの内容(data.results)を変数pokemonにセット、データが存在しない場合はから配列にする
+      .then(data => {
+        setPokemon(data.results || []);
+      })
+      // エラーが出た際にはコンソール上に出力する
+      .catch(error => console.error(error));
+  }, []);
+  
+  return (
+    <div className="App">
+      <div>
+        <h1>ポケモン図鑑 データリスト</h1>
+        <ul>
+          {pokemon.map((pokemonItem) => {
+            // URLをsplit("/")で"/"で区切り、slice(-2, -1)でidを取得。配列でデータが取得されるので、[0]で最初の要素を取得するß
+            const id = pokemonItem.url.split("/").slice(-2, -1)[0];
+            
+            return(
+                <li key={id}>
+                    <Link to={`/pokemon/${id}`}>{pokemonItem.name}</Link>
+                </li>);
+            })}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+export default PokemonList;
+// 他の場所でも使えるようにする


### PR DESCRIPTION
・詳細画面を作成
・一覧画面を別で作成し、App.jsから処理内容を移植
・データを日本語で取得できるように対応
・詳細画面には一覧画面へ戻ることができように「戻る」ボタンを配置
・API側のコントローラーの処理を一部修正